### PR TITLE
feature/revert-hide-invalid-mention-sensitive

### DIFF
--- a/src/components/popup/tabs/useroption/UserOption.vue
+++ b/src/components/popup/tabs/useroption/UserOption.vue
@@ -15,9 +15,9 @@ const options: UserOptionEntry[] = [
   { key: 'useTempraryWordSensitive', label: '禁止語句を使用したユーザーを一時的に非表示にします' },
   { key: 'useWordSensitive', label: '禁止語句を使用したユーザーを非表示ユーザーに登録します' },
   { key: 'useTempraryMensionSensitive', label: '非表示ユーザーへメンションしたユーザーを一時的に非表示にします' },
-  { key: 'useMentionSensitive', label: '非表示ユーザーへメンションしたユーザーを非表示ユーザーに登録します' },
-  { key: 'useTempraryInvalidMentionSensitive', label: '存在しないユーザーへメンションしたユーザーを一時的に非表示にします' },
-  { key: 'useInvalidMentionSensitive', label: '存在しないユーザーへメンションしたユーザーを非表示ユーザーに登録します' }
+  { key: 'useMentionSensitive', label: '非表示ユーザーへメンションしたユーザーを非表示ユーザーに登録します' }
+  // { key: 'useTempraryInvalidMentionSensitive', label: '存在しないユーザーへメンションしたユーザーを一時的に非表示にします' },
+  // { key: 'useInvalidMentionSensitive', label: '存在しないユーザーへメンションしたユーザーを非表示ユーザーに登録します' }
 ]
 </script>
 

--- a/src/composables/useBannedProcess.ts
+++ b/src/composables/useBannedProcess.ts
@@ -16,9 +16,10 @@ export function useBannedProcess(
         const { useWordSensitive,
           useTempraryWordSensitive,
           useMentionSensitive,
-          useTempraryMensionSensitive,
-          useInvalidMentionSensitive,
-          useTempraryInvalidMentionSensitive } = newUserOption
+          useTempraryMensionSensitive
+          // useInvalidMentionSensitive,
+          // useTempraryInvalidMentionSensitive
+        } = newUserOption
         switch (newResult?.type) {
           case 'Word':
             // 禁止ワードに抵触した
@@ -56,19 +57,19 @@ export function useBannedProcess(
             // 一時的に禁止のユーザーの発言をすべて非表示
             ycomment.elm.style.display = 'none'
             break
-          case 'InvalidMention':
-            // 存在しないユーザー宛のメンションを使用
-            if (useInvalidMentionSensitive) {
-              // 存在しないユーザーに対してメンションを送ったユーザーを永続的に禁止
-              upsertName(newResult.author)
-              ycomment.elm.style.display = 'none'
-            }
-            else if (useTempraryInvalidMentionSensitive) {
-              // 存在しないユーザーに対してメンションを送ったユーザーを一時的に禁止
-              upsertSessionName(newResult.author)
-              ycomment.elm.style.display = 'none'
-            }
-            break
+          // case 'InvalidMention':
+          //   // 存在しないユーザー宛のメンションを使用
+          //   if (useInvalidMentionSensitive) {
+          //     // 存在しないユーザーに対してメンションを送ったユーザーを永続的に禁止
+          //     upsertName(newResult.author)
+          //     ycomment.elm.style.display = 'none'
+          //   }
+          //   else if (useTempraryInvalidMentionSensitive) {
+          //     // 存在しないユーザーに対してメンションを送ったユーザーを一時的に禁止
+          //     upsertSessionName(newResult.author)
+          //     ycomment.elm.style.display = 'none'
+          //   }
+          //   break
         }
       }
     }

--- a/src/composables/useJudgeComment.ts
+++ b/src/composables/useJudgeComment.ts
@@ -6,7 +6,7 @@ import { UserOption } from './useUserOption'
 export type JudgeResult =
   | { isGuilty: true; type: 'Name' | 'Mention' | 'Session'; author: string; matchedUser: string }
   | { isGuilty: true; type: 'Word'; author: string; matchedWord: string }
-  | { isGuilty: true; type: 'InvalidMention' | 'Uncategorized'; author: string }
+  | { isGuilty: true; type: 'Uncategorized'; author: string }
   | { isGuilty: false; type?: never; author?: never; matchedUser?: never; matchedWord?: never };
 
 export function useJudgeComment(
@@ -17,7 +17,7 @@ export function useJudgeComment(
   userOption: Ref<UserOption>
 ): Ref<JudgeResult> {
 
-  const { author, commentBody: { mentions, text: commentText, invalidMention } } = commentObj
+  const { author, commentBody: { mentions, text: commentText } } = commentObj
 
   const result = computed<JudgeResult>(() => {
     // ignoreName
@@ -65,15 +65,15 @@ export function useJudgeComment(
       }
     }
 
-    // invalidMention
-    const matchedInvalidMention = (userOption.value.useInvalidMentionSensitive || userOption.value.useTempraryInvalidMentionSensitive) && invalidMention
-    if (matchedInvalidMention) {
-      return {
-        isGuilty: true,
-        type: 'InvalidMention',
-        author
-      }
-    }
+    //// invalidMention
+    //const matchedInvalidMention = (userOption.value.useInvalidMentionSensitive || userOption.value.useTempraryInvalidMentionSensitive) && invalidMention
+    //if (matchedInvalidMention) {
+    //  return {
+    //    isGuilty: true,
+    //    type: 'InvalidMention',
+    //    author
+    //  }
+    //}
 
     return { isGuilty: false }
   })

--- a/src/composables/useUserOption.ts
+++ b/src/composables/useUserOption.ts
@@ -12,8 +12,8 @@ export interface UserOption {
   useTempraryWordSensitive: boolean
   useMentionSensitive: boolean
   useTempraryMensionSensitive: boolean
-  useInvalidMentionSensitive: boolean
-  useTempraryInvalidMentionSensitive: boolean
+  // useInvalidMentionSensitive: boolean
+  // useTempraryInvalidMentionSensitive: boolean
 }
 
 export type UserOptionEvent =
@@ -76,15 +76,15 @@ export default function () {
           }
         }
 
-        // useTempraryMensionSensitive, useMentionSensitive の排他制御
-        if (key === 'useTempraryInvalidMentionSensitive' || key === 'useInvalidMentionSensitive') {
-          if (memoryCache.value.useTempraryInvalidMentionSensitive && key === 'useInvalidMentionSensitive') {
-            memoryCache.value.useTempraryInvalidMentionSensitive = false;
-          }
-          else if (memoryCache.value.useInvalidMentionSensitive && key === 'useTempraryInvalidMentionSensitive') {
-            memoryCache.value.useInvalidMentionSensitive = false;
-          }
-        }
+        // // useTempraryMensionSensitive, useMentionSensitive の排他制御
+        // if (key === 'useTempraryInvalidMentionSensitive' || key === 'useInvalidMentionSensitive') {
+        //   if (memoryCache.value.useTempraryInvalidMentionSensitive && key === 'useInvalidMentionSensitive') {
+        //     memoryCache.value.useTempraryInvalidMentionSensitive = false;
+        //   }
+        //   else if (memoryCache.value.useInvalidMentionSensitive && key === 'useTempraryInvalidMentionSensitive') {
+        //     memoryCache.value.useInvalidMentionSensitive = false;
+        //   }
+        // }
 
         memoryCache.value[event.key] = !memoryCache.value[event.key]
         break;

--- a/src/utils/defaultUserOption.ts
+++ b/src/utils/defaultUserOption.ts
@@ -7,7 +7,7 @@ export const getDefaultUserOption = (): UserOption => ({
   useTempraryWordSensitive: false,
   useWordSensitive: false,
   useTempraryMensionSensitive: false,
-  useMentionSensitive: false,
-  useTempraryInvalidMentionSensitive: false,
-  useInvalidMentionSensitive: false
+  useMentionSensitive: false
+  // useTempraryInvalidMentionSensitive: false
+  // useInvalidMentionSensitive: false
 })

--- a/src/utils/getComment.ts
+++ b/src/utils/getComment.ts
@@ -1,7 +1,7 @@
 export interface YCommentBody {
   mentions: string[];
   text: string;
-  invalidMention: boolean;
+  // invalidMention: boolean;
 }
 
 /**
@@ -28,11 +28,12 @@ export default function getComment(elm: HTMLElement): YComment {
 
 function extractTextFromElement(element: Element | null): YCommentBody {
   if (!element) {
-    return { mentions: [], text: '', invalidMention: false }; // 要素がない場合、空のデータを返す
+    // return { mentions: [], text: '', invalidMention: false }; // 要素がない場合、空のデータを返す
+    return { mentions: [], text: '' }; // 要素がない場合、空のデータを返す
   }
   const anchorTexts: string[] = [];
   let outerText = '';
-  let invalidMention = false
+  // let invalidMention = false
 
   // 子ノードをループ
   element.childNodes.forEach((node) => {
@@ -48,12 +49,13 @@ function extractTextFromElement(element: Element | null): YCommentBody {
     else if (node.nodeType === Node.TEXT_NODE) {
       const { textContent } = node
       if (textContent) {
-        const invalidMentionPattern = new RegExp(/^(@\S+)\s/); // 空白以外の文字にマッチするよう修正
-        invalidMention = invalidMentionPattern.test(textContent)
+        // const invalidMentionPattern = new RegExp(/^(@\S+)\s/); // 空白以外の文字にマッチするよう修正
+        // invalidMention = invalidMentionPattern.test(textContent)
         // 一番外側の span に囲まれていないテキスト
         outerText += textContent.trim();
       }
     }
   });
-  return { mentions: anchorTexts, text: outerText, invalidMention };
+  // return { mentions: anchorTexts, text: outerText, invalidMention };
+  return { mentions: anchorTexts, text: outerText }
 }


### PR DESCRIPTION
存在しないユーザーへのメンションを非表示にする機能を無効化

修正の理由：
正しくメンション化できていないメンション付きコメント、@への返信(通知がいかない配慮?)の使用など、消すほどでもないものまで巻き込んでしまうため