### PR TITLE
GitHub Actionsの最適化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Release to Chrome Web Store
 on:
   push:
     branches:
-      - 'test/fix-workflow-import-env'
+      - "test/fix-workflow-import-env"
     tags:
-      - 'v[0-9]+.[0-9]+.0'  # minor以上のアップデートをトリガーにする
-  workflow_dispatch:   # 👈 手動実行を許可
+      - "v[0-9]+.[0-9]+.0" # minor以上のアップデートをトリガーにする
+  workflow_dispatch: # 手動実行を許可
 
 jobs:
   release:
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -29,31 +29,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --prod --no-frozen-lockfile
 
-      - name: Load npm package metadata
-        run: |
-          echo "PACKAGE_NAME=$(jq -r .name package.json)" >> $GITHUB_ENV
-          echo "PACKAGE_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
-
-      - name: Create .env
-        run: echo "${{ secrets.ENV }}" > .env
-
       - name: Create .env.submit
         run: echo "${{ secrets.ENV_SUBMIT }}" > .env.submit
 
-      - name: Run build step
-        run: pnpm build
-
-      - name: Run zip step
+      - name: Build and Zip
         run: pnpm zip
 
-      - name: Upload build artifact
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
-        env:
-          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
-          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         with:
-          # name: download-zip # 保存ファイル名を指定する場合、拡張子不要
-          path: .output/${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-chrome.zip
+          path: .output/*.zip
+          if-no-files-found: error
+          include-hidden-files: true
 
       - name: Run dryrun-unix script
         run: pnpm dryrun-unix

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write  # リポジトリの内容に書き込み権限を付与
+  contents: write # リポジトリの内容に書き込み権限を付与
 
 jobs:
   bump-version:
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -39,4 +39,4 @@ jobs:
           git commit -m "chore: bump patch version [skip ci]"
           git push origin main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # トークンを使用してプッシュ
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # トークンを使用してプッシュ

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ web-ext.config.ts
 
 # Editor directories and files
 .vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo
@@ -30,3 +29,6 @@ web-ext.config.ts
 *.njsproj
 *.sln
 *.sw?
+
+!.vscode/settings.example.json
+!.vscode/extensions.json

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,0 +1,15 @@
+{
+  "eslint.useFlatConfig": true,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "never",
+    "source.fixAll.eslint": "explicit"
+  },
+  "files.associations": {
+    "*.json": "jsonc",
+    "package.json": "json"
+  },
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "typescript.preferences.preferTypeOnlyAutoImports": true
+}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,3 +1,5 @@
+name: YouTube Comment Block
+description: block comment for Videos/Shorts
 format:
   date: MM/DD/YY
   time: HH:mm:ss

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1,3 +1,5 @@
+name: YouTube Comment Block
+description: 動画とショート動画の該当コメントを非表示にします
 format:
   date: YY/MM/DD
   time: HH:mm:ss

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   srcDir: 'src',
   // extensionApi: 'chrome',
   modules: ['@wxt-dev/i18n/module', '@wxt-dev/module-vue', '@wxt-dev/auto-icons'],
+  autoIcons: {
+    developmentIndicator: false,
+  },
 
   vite: () => {
     const isProd = process.env.NODE_ENV === 'production'
@@ -21,8 +24,8 @@ export default defineConfig({
 
   manifest: () => ({
     permissions: ['storage'],
-    name: process.env.NODE_ENV === 'production' ? import.meta.env.WXT_EXT_NAME : `(Dev)${import.meta.env.WXT_EXT_NAME}`,
-    description: import.meta.env.WXT_EXT_DESC,
+    name: '__MSG_name__',
+    description: '__MSG_description__',
     default_locale: 'en',
   }),
 })


### PR DESCRIPTION
actions/checkout@v4 から v5 へ

その他
extensionNameとdescriptionをlocale/*.ymlからの参照に変更
.envを使わなくなったので廃止